### PR TITLE
Add build-only npm script

### DIFF
--- a/app/app/package.json
+++ b/app/app/package.json
@@ -10,6 +10,7 @@
     "start": "astro dev",
     "check": "astro check",
     "build": "astro check && astro build",
+    "build-only": "astro build",
     "preview": "astro preview",
     "astro": "astro"
   },


### PR DESCRIPTION
Fix missing `build-only` npm script in #28 